### PR TITLE
fix: force uuid >=11.1.1 to address CVE-2026-41907

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3754,15 +3754,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "typescript": "^5.4.5",
     "vite": "^6.4.2"
   },
+  "overrides": {
+    "uuid": "^11.1.1"
+  },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
     "@fortawesome/free-brands-svg-icons": "^6.7.2",


### PR DESCRIPTION
## Summary

- `uuid <11.1.1` has a missing buffer bounds check in `v3()`/`v5()`/`v6()` when an external output buffer is provided, allowing silent partial writes ([GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq), CVE-2026-41907)
- `uuid` is a transitive dependency of `@owlbear-rodeo/sdk`, which pins `^9.0.0` — a direct upgrade is not possible
- Added an npm `overrides` entry to force `uuid >=11.1.1` across all dependents

Closes https://github.com/alvarocavalcanti/map-location-keys/security/dependabot/28

## Test plan

- [x] `uuid` in `package-lock.json` is now `11.1.1`
- [x] `npx tsc --noEmit` passes with no errors
- [x] `npm audit` no longer reports the uuid vulnerability