### PR TITLE
Settings tab and add Show Player Info in GM View option

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## Version 2026-07-11
+
+### GM View Player Information Setting
+
+- Added a new Settings option to show Player Information directly in the GM location key list
+- When enabled, Player Information is displayed beneath the primary location details for each expanded location key
+
+---
+
 ## Version 2026-06-16
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "map-location-keys",
-  "version": "2026-06-16",
+  "version": "2026-07-11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "map-location-keys",
-      "version": "2026-06-16",
+      "version": "2026-07-11",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-brands-svg-icons": "^6.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "map-location-keys",
   "private": true,
-  "version": "2026-06-16",
+  "version": "2026-07-11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Map Location Keys",
-  "version": "2026-06-16",
+  "version": "2026-07-11",
   "manifest_version": 1,
   "icon": "/img/logo.png",
   "author": "Alvaro Cavalcanti",

--- a/src/components/GMViewSettings.tsx
+++ b/src/components/GMViewSettings.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+interface GMViewSettingsProps {
+  showPlayerInfoInGMView: boolean;
+  onShowPlayerInfoInGMViewChange: (enabled: boolean) => void;
+}
+
+const GMViewSettings: React.FC<GMViewSettingsProps> = ({
+  showPlayerInfoInGMView,
+  onShowPlayerInfoInGMViewChange,
+}) => {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-600 p-4 mb-3">
+      <h2 className="text-lg font-semibold mb-3 text-gray-900 dark:text-white">
+        GM View
+      </h2>
+      <p className="text-gray-700 dark:text-gray-300 mb-3 text-sm">
+        Control which player-facing details are also shown in the GM list:
+      </p>
+      <label className="flex items-start gap-3 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={showPlayerInfoInGMView}
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+            onShowPlayerInfoInGMViewChange(event.target.checked)
+          }
+          className="mt-1"
+        />
+        <span>
+          <span className="block text-gray-900 dark:text-white font-medium">
+            Show Player Information in GM view
+          </span>
+          <span className="block text-sm text-gray-700 dark:text-gray-300">
+            Display each location key&apos;s Player Information beneath the
+            primary details in the GM list.
+          </span>
+        </span>
+      </label>
+    </div>
+  );
+};
+
+export default GMViewSettings;

--- a/src/components/Help.tsx
+++ b/src/components/Help.tsx
@@ -6,11 +6,9 @@ import { faBluesky } from "@fortawesome/free-brands-svg-icons";
 import { faTwitter } from "@fortawesome/free-brands-svg-icons";
 import { faGithub } from "@fortawesome/free-brands-svg-icons";
 import { faGlobeAfrica } from "@fortawesome/free-solid-svg-icons";
-import ThemeSelector from "./ThemeSelector";
-import { ThemeId } from "../themes";
 import DonationButtons from "./DonationButtons";
 
-const Help: React.FC<{ version: string; currentTheme: ThemeId; onThemeChange: (theme: ThemeId) => void }> = ({ version, currentTheme, onThemeChange }) => {
+const Help: React.FC<{ version: string }> = ({ version }) => {
   const [activeSection, setActiveSection] = React.useState<string>("");
 
   const itemsAdd: { header: string; image: string; description?: string }[] = [
@@ -177,8 +175,6 @@ const Help: React.FC<{ version: string; currentTheme: ThemeId; onThemeChange: (t
 
   return (
     <>
-      <ThemeSelector currentTheme={currentTheme} onThemeChange={onThemeChange} />
-
       <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-600 p-4 mb-3">
         <h2 className="text-lg font-semibold mb-2 text-gray-900 dark:text-white">Video Tutorial</h2>
         <YouTube videoId="jJM_600M1eo" opts={opts} />

--- a/src/components/Homepage.tsx
+++ b/src/components/Homepage.tsx
@@ -203,7 +203,7 @@ const Homepage: React.FC = () => {
           </li>
         </ul>
         <h2 className="text-2xl font-semibold mb-3 text-gray-900 dark:text-white">Help Topics</h2>
-        <Help version={version} currentTheme="dark-fantasy" onThemeChange={() => {}} />
+        <Help version={version} />
       </div>
     </div>
   );

--- a/src/components/LocationKeys.tsx
+++ b/src/components/LocationKeys.tsx
@@ -14,7 +14,8 @@ import DonationButtons from "./DonationButtons";
 const LocationKeys: React.FC<{
   setLocationKeyToEdit: (locationKey: LocationKey) => void;
   locationKeys: LocationKey[];
-}> = ({ setLocationKeyToEdit: setLocationKeyToEdit, locationKeys }) => {
+  showPlayerInfoInGMView: boolean;
+}> = ({ setLocationKeyToEdit: setLocationKeyToEdit, locationKeys, showPlayerInfoInGMView }) => {
   const [locationToReveal, setLocationToReveal] = React.useState<string>("");
 
   const handleToggleClick = (id: string) => {
@@ -107,6 +108,20 @@ const LocationKeys: React.FC<{
                     <div className="markdown-content mb-3 p-3 bg-gray-50 dark:bg-gray-900 rounded border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300">
                       <MarkdownRenderer>{locationKey.description || ""}</MarkdownRenderer>
                     </div>
+                    {showPlayerInfoInGMView && (
+                      <div className="mb-3">
+                        <h3 className="text-sm font-semibold mb-2 text-gray-900 dark:text-white">Player Information</h3>
+                        {locationKey.playerInfo ? (
+                          <div className="markdown-content p-3 bg-blue-50 dark:bg-blue-950/30 rounded border border-blue-200 dark:border-blue-900 text-gray-700 dark:text-gray-300">
+                            <MarkdownRenderer>{locationKey.playerInfo}</MarkdownRenderer>
+                          </div>
+                        ) : (
+                          <p className="text-sm text-gray-500 dark:text-gray-400 italic">
+                            No player information provided.
+                          </p>
+                        )}
+                      </div>
+                    )}
                     <div className="grid grid-cols-4 gap-2 text-center mt-1">
                       <Link to={`/location-key/${locationKey.id}`}>
                         <button

--- a/src/components/SPA.tsx
+++ b/src/components/SPA.tsx
@@ -24,6 +24,7 @@ import AddDeleteAll from "./AddDeleteAll";
 import { useTheme } from "../hooks/useTheme";
 import { ColorMode } from "../themes";
 import WhatsNew from "./WhatsNew";
+import Settings from "./Settings";
 
 export default function SPA() {
   const [locationKeyToEdit, setLocationKeyToEdit] = React.useState(
@@ -116,6 +117,8 @@ export default function SPA() {
       setActiveTab("tools");
     } else if (location.pathname === paths.help) {
       setActiveTab("help");
+    } else if (location.pathname === paths.settings) {
+      setActiveTab("settings");
     } else if (location.pathname === "/") {
       setActiveTab("location-keys");
     }
@@ -130,6 +133,8 @@ export default function SPA() {
         navigate(paths.importExport);
       } else if (key === "help") {
         navigate(paths.help);
+      } else if (key === "settings") {
+        navigate(paths.settings);
       }
     }
   };
@@ -167,6 +172,16 @@ export default function SPA() {
             }`}
           >
             Tools
+          </button>
+          <button
+            onClick={() => handleTabSelect("settings")}
+            className={`px-4 py-2 font-medium text-sm ${
+              activeTab === "settings"
+                ? "border-b-2 border-blue-500 text-blue-600 dark:text-blue-300"
+                : "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+            }`}
+          >
+            Settings
           </button>
           <button
             onClick={() => handleTabSelect("help")}
@@ -251,7 +266,8 @@ export default function SPA() {
           path={paths.bulkActions}
           element={<AddDeleteAll />}
         />
-        <Route path={paths.help} element={<Help version={version} currentTheme={themeId} onThemeChange={changeTheme} />} />
+        <Route path={paths.help} element={<Help version={version} />} />
+        <Route path={paths.settings} element={<Settings currentTheme={themeId} onThemeChange={changeTheme} />} />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
     </div>

--- a/src/components/SPA.tsx
+++ b/src/components/SPA.tsx
@@ -22,6 +22,7 @@ import { paths } from "./util/constants";
 import PlayerView from "./PlayerView";
 import AddDeleteAll from "./AddDeleteAll";
 import { useTheme } from "../hooks/useTheme";
+import { usePlayerInfoInGMView } from "../hooks/usePlayerInfoInGMView";
 import { ColorMode } from "../themes";
 import WhatsNew from "./WhatsNew";
 import Settings from "./Settings";
@@ -35,7 +36,8 @@ export default function SPA() {
   const [role, setRole] = React.useState<"GM" | "PLAYER">("GM");
   const [activeTab, setActiveTab] = useState<string>("location-keys");
   const [colorMode, setColorMode] = useState<ColorMode>('dark');
-  const { themeId, changeTheme } = useTheme(colorMode);
+  const [themeId, setThemeId] = useTheme(colorMode);
+  const [showPlayerInfoInGMView, setShowPlayerInfoInGMView] = usePlayerInfoInGMView();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -242,6 +244,7 @@ export default function SPA() {
             <LocationKeys
               setLocationKeyToEdit={setLocationKeyToEdit}
               locationKeys={locationKeys}
+              showPlayerInfoInGMView={showPlayerInfoInGMView}
             />
           }
         />
@@ -267,7 +270,17 @@ export default function SPA() {
           element={<AddDeleteAll />}
         />
         <Route path={paths.help} element={<Help version={version} />} />
-        <Route path={paths.settings} element={<Settings currentTheme={themeId} onThemeChange={changeTheme} />} />
+        <Route
+          path={paths.settings}
+          element={
+            <Settings
+              currentTheme={themeId}
+              onThemeChange={setThemeId}
+              showPlayerInfoInGMView={showPlayerInfoInGMView}
+              onShowPlayerInfoInGMViewChange={setShowPlayerInfoInGMView}
+            />
+          }
+        />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
     </div>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ThemeSelector from "./ThemeSelector";
+import { ThemeId } from "../themes";
+
+const Settings: React.FC<{ currentTheme: ThemeId; onThemeChange: (theme: ThemeId) => void }> = ({ currentTheme, onThemeChange }) => {
+  return (
+    <>
+      <ThemeSelector currentTheme={currentTheme} onThemeChange={onThemeChange} />
+    </>
+  );
+};
+
+export default Settings;

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,11 +1,26 @@
 import React from "react";
 import ThemeSelector from "./ThemeSelector";
+import GMViewSettings from "./GMViewSettings";
 import { ThemeId } from "../themes";
 
-const Settings: React.FC<{ currentTheme: ThemeId; onThemeChange: (theme: ThemeId) => void }> = ({ currentTheme, onThemeChange }) => {
+const Settings: React.FC<{
+  currentTheme: ThemeId;
+  onThemeChange: React.Dispatch<ThemeId>;
+  showPlayerInfoInGMView: boolean;
+  onShowPlayerInfoInGMViewChange: React.Dispatch<boolean>;
+}> = ({
+  currentTheme,
+  onThemeChange,
+  showPlayerInfoInGMView,
+  onShowPlayerInfoInGMViewChange,
+}) => {
   return (
     <>
       <ThemeSelector currentTheme={currentTheme} onThemeChange={onThemeChange} />
+      <GMViewSettings
+        showPlayerInfoInGMView={showPlayerInfoInGMView}
+        onShowPlayerInfoInGMViewChange={onShowPlayerInfoInGMViewChange}
+      />
     </>
   );
 };

--- a/src/components/util/constants.ts
+++ b/src/components/util/constants.ts
@@ -4,6 +4,7 @@ export const paths: { [key: string]: string } = {
   importExport: "/import-export",
   fogExportImport: "/fog-export-import",
   help: "/help",
+  settings: "/settings",
   playerView: "/player-view",
   bulkActions: "/bulk-actions",
 };

--- a/src/hooks/usePlayerInfoInGMView.ts
+++ b/src/hooks/usePlayerInfoInGMView.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react';
+
+const SHOW_PLAYER_INFO_IN_GM_VIEW_STORAGE_KEY =
+  "map-location-keys-settings-playerinfo-in-gm-view";
+
+export const usePlayerInfoInGMView = (): [boolean, React.Dispatch<boolean>] => {
+  const [playerInfoInGMView, setPlayerInfoInGMView] =
+    useState<boolean>(() => {
+      const stored = localStorage.getItem(SHOW_PLAYER_INFO_IN_GM_VIEW_STORAGE_KEY) === "true";
+      return stored;
+    });
+
+  useEffect(() => {
+    localStorage.setItem(SHOW_PLAYER_INFO_IN_GM_VIEW_STORAGE_KEY, playerInfoInGMView.toString());
+  }, [playerInfoInGMView]);
+
+  return [playerInfoInGMView, setPlayerInfoInGMView ];
+};

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -3,13 +3,15 @@ import { themes, ThemeId, ColorMode } from '../themes';
 
 const THEME_STORAGE_KEY = 'map-location-keys-theme';
 
-export const useTheme = (colorMode: ColorMode) => {
+export const useTheme = (colorMode: ColorMode): [ThemeId, React.Dispatch<ThemeId>] => {
   const [themeId, setThemeId] = useState<ThemeId>(() => {
     const stored = localStorage.getItem(THEME_STORAGE_KEY);
     return (stored as ThemeId) || 'dark-fantasy';
   });
 
   useEffect(() => {
+    localStorage.setItem(THEME_STORAGE_KEY, themeId);
+
     const theme = themes[themeId];
     const colors = colorMode === 'dark' ? theme.dark : theme.light;
 
@@ -32,10 +34,5 @@ export const useTheme = (colorMode: ColorMode) => {
     root.style.setProperty('--color-border-hover', colors.borderHover);
   }, [themeId, colorMode]);
 
-  const changeTheme = (newTheme: ThemeId) => {
-    setThemeId(newTheme);
-    localStorage.setItem(THEME_STORAGE_KEY, newTheme);
-  };
-
-  return { themeId, changeTheme };
+  return [ themeId, setThemeId ];
 };

--- a/src/releaseNotes.ts
+++ b/src/releaseNotes.ts
@@ -6,6 +6,14 @@ export interface ReleaseHighlight {
 
 export const releaseHighlights: ReleaseHighlight[] = [
   {
+    version: "2026-07-11",
+    date: "July 11, 2026",
+    highlights: [
+      "⚙️ New GM setting to show Player Information directly in the GM location key list",
+      "👀 Player Information now appears beneath the primary details section when the setting is enabled"
+    ]
+  },
+  {
     version: "2026-06-16",
     date: "June 16, 2026",
     highlights: [


### PR DESCRIPTION
Added new GM (Game Master) setting that allows Player Information to be displayed directly in the GM's view, along with associated UI and settings infrastructure. It also refactors theme and setting management for better consistency and persistence, and updates documentation and metadata for a new release.

**Problem / Solution**:

- I often found myself duplicating notes between the GM notes and the Player notes. The idea here is that for things like descriptions read to the players and other handouts, theres no need to duplicate them if they are just Immediately visible to me as well.

**New GM View Feature:**

- Added a setting to enable showing Player Information in the GM location key list, including a new `GMViewSettings` component and a toggle in the Settings page. When enabled, Player Information appears beneath the location details for each expanded location key. 

**Settings and Theme Management Improvements:**

- Introduced a unified Settings tab, moving theme selection and GM View settings into it, and updated navigation and routing to support the new page. Theme and GM View setting state persistence is simplified slightly using stricter typing. 

---
<img width="945" height="691" alt="image" src="https://github.com/user-attachments/assets/9d35f9f9-6d39-42d0-883e-f7c2066f853e" />
