### PR TITLE
fix(theme): restore Tailwind default colors to fix unstyled elements

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,6 @@
 @import "tailwindcss";
 
 @theme {
-  --color-*: initial;
   --breakpoint-*: initial;
 }
 


### PR DESCRIPTION
This PR fixes a pre-existing issue introduced during the Tailwind v4 migration where `--color-*: initial;` was used in the `@theme` block, which inadvertently disabled all default Tailwind utility classes (such as `bg-white`, `bg-gray-50`, `border-gray-300`, etc.) and rendered those elements as transparent/unstyled. This restores the default colors so the extension styles render correctly.